### PR TITLE
do empty state check after setting adapter

### DIFF
--- a/src/main/java/com/carrotcreative/recyclercore/widget/ProgressRecyclerViewLayout.java
+++ b/src/main/java/com/carrotcreative/recyclercore/widget/ProgressRecyclerViewLayout.java
@@ -124,6 +124,7 @@ public class ProgressRecyclerViewLayout extends RelativeLayout
         mAdapter.registerAdapterDataObserver(mDataObserver);
         mRecyclerView.setAdapter(adapter);
         mProgressBar.setVisibility(GONE);
+        checkEmptyState();
     }
 
     public void setOnScrollListener(RecyclerView.OnScrollListener scrollListener)


### PR DESCRIPTION
Just found a bug, empty state was not getting set because the adapter size was 0
