### PR TITLE
add prefix rv_core to layout/ids

### DIFF
--- a/recycler-core/src/main/java/com/carrotcreative/recyclercore/widget/ProgressRecyclerViewLayout.java
+++ b/recycler-core/src/main/java/com/carrotcreative/recyclercore/widget/ProgressRecyclerViewLayout.java
@@ -56,7 +56,7 @@ public class ProgressRecyclerViewLayout extends RelativeLayout
         // Inflating the View
         LayoutInflater inflater = (LayoutInflater) context
                 .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-        inflater.inflate(R.layout.progress_recycler_view, this, true);
+        inflater.inflate(R.layout.rv_core_progress_recycler_view, this, true);
 
         // prepare the views
         findViews();
@@ -76,9 +76,9 @@ public class ProgressRecyclerViewLayout extends RelativeLayout
 
     private void findViews()
     {
-        mContainer = (FrameLayout) findViewById(R.id.progress_recycler_view_container);
-        mCoreRecyclerView = (RecyclerCoreRecyclerView) findViewById(R.id.progress_recycler_view_recycler_view);
-        mProgressBar = (ProgressBar) findViewById(R.id.progress_recycler_view_progress_bar);
+        mContainer = (FrameLayout) findViewById(R.id.rv_core_progress_recycler_view_container);
+        mCoreRecyclerView = (RecyclerCoreRecyclerView) findViewById(R.id.rv_core_progress_recycler_view_recycler_view);
+        mProgressBar = (ProgressBar) findViewById(R.id.rv_core_progress_recycler_view_progress_bar);
     }
 
     private void setDefaultLayoutManager()

--- a/recycler-core/src/main/res/layout/rv_core_progress_recycler_view.xml
+++ b/recycler-core/src/main/res/layout/rv_core_progress_recycler_view.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/progress_recycler_view_container"
+    android:id="@+id/rv_core_progress_recycler_view_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     >
 
     <com.carrotcreative.recyclercore.widget.RecyclerCoreRecyclerView
-        android:id="@+id/progress_recycler_view_recycler_view"
+        android:id="@+id/rv_core_progress_recycler_view_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         />
 
     <ProgressBar
-        android:id="@+id/progress_recycler_view_progress_bar"
+        android:id="@+id/rv_core_progress_recycler_view_progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"


### PR DESCRIPTION
closes #38 
- add a prefix `rv_core`, to layout and its id's to reduce the changes of name collision with the app. 
